### PR TITLE
Fixed building with VS2019

### DIFF
--- a/al-khaser/AntiDebug/ParentProcess.cpp
+++ b/al-khaser/AntiDebug/ParentProcess.cpp
@@ -1,6 +1,9 @@
 #include "pch.h"
 #include "ParentProcess.h"
 
+#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
+#include <experimental/filesystem>
+
 DWORD GetExplorerPIDbyShellWindow()
 {
 	DWORD dwProcessId = 0;


### PR DESCRIPTION
While trying to build with **Visual Studio 2019**, the following errors occur:

![alkhaser_errors](https://user-images.githubusercontent.com/3115348/137459571-89df0dcf-ab0c-407f-8380-00c3c82060a3.png)

The proposed patch makes the build successful:

![alkhaser_build_ok](https://user-images.githubusercontent.com/3115348/137460126-f6dea655-98f9-4729-8e9a-b77749dfef09.png)
