### PR TITLE
Add check for WAET ACPI table presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
   - SMBIOS string checks (VMWare)
   - SMBIOS string checks (Qemu)
   - SMBIOS number of tables (Qemu, VirtualBox)
+  - ACPI string checks (WAET table)
   - ACPI string checks (VirtualBox)
   - ACPI string checks (VMWare)
   - ACPI string checks (Qemu)

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -214,6 +214,7 @@ int main(int argc, char* argv[])
 		exec_check(&registry_services_disk_enum, TEXT("Checking Services\\Disk\\Enum entries for VM strings "));
 		exec_check(&registry_disk_enum, TEXT("Checking Enum\\IDE and Enum\\SCSI entries for VM strings "));
 		exec_check(&number_SMBIOS_tables, TEXT("Checking SMBIOS tables  "));
+		exec_check(&firmware_ACPI_WAET, TEXT("Checking if ACPI WAET table is present "));
 	}
 
 	/* VirtualBox Detection */

--- a/al-khaser/AntiVM/Generic.h
+++ b/al-khaser/AntiVM/Generic.h
@@ -50,3 +50,4 @@ BOOL pirated_windows();
 BOOL registry_services_disk_enum();
 BOOL registry_disk_enum();
 BOOL number_SMBIOS_tables();
+BOOL firmware_ACPI_WAET();


### PR DESCRIPTION
Windows ACPI Emulated devices Table is a special table provided by hypervisors for improving Windows guest stability.
Spec:  https://download.microsoft.com/download/7/E/7/7E7662CF-CBEA-470B-A97E-CE7CE0D98DC2/WAET.docx

Both QEMU and Virtualbox build WAET table in their sources, and probably VMWare too
