### PR TITLE
Implement advanced ACPI scan for generic sandbox & QEMU

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Please, if you encounter any of the anti-analysis tricks which you have seen in 
   - SMBIOS string checks (VMWare)
   - SMBIOS string checks (Qemu)
   - SMBIOS number of tables (Qemu, VirtualBox)
-  - ACPI string checks (WAET table)
+  - ACPI string checks (WAET table, PNP devices, PM state with battery checks)
   - ACPI string checks (VirtualBox)
   - ACPI string checks (VMWare)
   - ACPI string checks (Qemu)

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -216,7 +216,7 @@ int main(int argc, char* argv[])
 		exec_check(&registry_services_disk_enum, TEXT("Checking Services\\Disk\\Enum entries for VM strings "));
 		exec_check(&registry_disk_enum, TEXT("Checking Enum\\IDE and Enum\\SCSI entries for VM strings "));
 		exec_check(&number_SMBIOS_tables, TEXT("Checking SMBIOS tables  "));
-		exec_check(&firmware_ACPI_WAET, TEXT("Checking if ACPI WAET table is present "));
+		exec_check(&firmware_ACPI, TEXT("Checking ACPI table strings "));
 	}
 
 	/* VirtualBox Detection */

--- a/al-khaser/AntiVM/Generic.h
+++ b/al-khaser/AntiVM/Generic.h
@@ -50,6 +50,6 @@ BOOL pirated_windows();
 BOOL registry_services_disk_enum();
 BOOL registry_disk_enum();
 BOOL number_SMBIOS_tables();
-BOOL firmware_ACPI_WAET();
+BOOL firmware_ACPI();
 BOOL hosting_check();
 VOID looking_glass_vdd_processes();


### PR DESCRIPTION
This PR adds advanced ACPI checks for generic sandboxes & QEMU

After a small research I discovered that QEMU sets PM=0 (1 = desktop, 2 = mobile) so we need to account ACPI battery
For generic sandboxie detection I introduced checks agains PNP devices that are present on all PCs