### PR TITLE
 fix build warnings and apply code style

### DIFF
--- a/al-khaser/AntiDebug/ScanForModules.cpp
+++ b/al-khaser/AntiDebug/ScanForModules.cpp
@@ -99,7 +99,7 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 
 #ifdef _X86_
 	TCHAR syswow64Path[MAX_PATH];
-	SHGetFolderPath (NULL, CSIDL_SYSTEMX86, NULL, 0, syswow64Path);
+	SHGetFolderPath(NULL, CSIDL_SYSTEMX86, NULL, 0, syswow64Path);
 	StringCbCat(syswow64Path, MAX_PATH, _T("\\"));
 	size_t syswow64PathLength = 0;
 	StringCbLength(syswow64Path, MAX_PATH, &syswow64PathLength);
@@ -120,7 +120,7 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 
 			//printf("systemDriveDevice: %S (%d)\n", systemDriveDevice, systemDriveDevicelength);
 
-			if (StrNCmpI(systemDriveDevice, filename, (int)(min(systemDriveDevicelength, filenameLength) / sizeof(TCHAR)) ) == 0)
+			if (StrNCmpI(systemDriveDevice, filename, (int)(min(systemDriveDevicelength, filenameLength) / sizeof(TCHAR))) == 0)
 			{
 				// path matched the NT file path
 				return false;
@@ -132,14 +132,14 @@ bool IsBadLibrary(TCHAR* filename, DWORD filenameLength)
 
 			//printf("systemRootPath: %S (%d)\n", systemRootPath, systemRootPathLength);
 
-			if (StrNCmpI(systemRootPath, normalisedPath, (int)(min(systemRootPathLength, normalisedPathLength) / sizeof(TCHAR)) ) == 0)
+			if (StrNCmpI(systemRootPath, normalisedPath, (int)(min(systemRootPathLength, normalisedPathLength) / sizeof(TCHAR))) == 0)
 			{
 				// path matched the regular system path
 				return false;
 			}
 
 #ifdef _X86_
-			if (IsWoW64() && StrNCmpI(syswow64Path, normalisedPath, (int)(min(syswow64PathLength, normalisedPathLength) / sizeof(TCHAR)) ) == 0)
+			if (IsWoW64() && StrNCmpI(syswow64Path, normalisedPath, (int)(min(syswow64PathLength, normalisedPathLength) / sizeof(TCHAR))) == 0)
 			{
 				// path matched the wow64 system path
 				return false;
@@ -164,7 +164,7 @@ BOOL ScanForModules_EnumProcessModulesEx_Internal(DWORD moduleFlag)
 	DWORD currentSize = 1024 * sizeof(HMODULE);
 	DWORD requiredSize = 0;
 	bool anyBadLibs = false;
-	
+
 	// the EnumProcessModulesEx API was moved from psapi.dll into kernel32.dll for Windows 7, then back out afterwards.
 	// check for availability of either.
 	if (!API::IsAvailable(API_EnumProcessModulesEx_PSAPI) && !API::IsAvailable(API_EnumProcessModulesEx_Kernel))
@@ -172,7 +172,7 @@ BOOL ScanForModules_EnumProcessModulesEx_Internal(DWORD moduleFlag)
 		// neither available
 		return FALSE;
 	}
-	
+
 	// API is available in one of the two libraries, use whichever is available.
 	pEnumProcessModulesEx fnEnumProcessModulesEx;
 	if (API::IsAvailable(API_EnumProcessModulesEx_PSAPI))
@@ -235,7 +235,7 @@ BOOL ScanForModules_EnumProcessModulesEx_32bit()
 
 BOOL ScanForModules_EnumProcessModulesEx_64bit()
 {
-	
+
 	return ScanForModules_EnumProcessModulesEx_Internal(LIST_MODULES_64BIT);
 }
 
@@ -270,7 +270,7 @@ BOOL ScanForModules_MemoryWalk_GMI()
 
 		//printf("Scanning %p - %p ...\n", addr, regionEnd);
 
-		while(addr < regionEnd)
+		while (addr < regionEnd)
 		{
 			bool skippedForward = false;
 			if (VirtualQuery(addr, &memInfo, sizeof(MEMORY_BASIC_INFORMATION)) >= sizeof(MEMORY_BASIC_INFORMATION))
@@ -338,16 +338,16 @@ BOOL ScanForModules_MemoryWalk_Hidden()
 		while (addr < regionEnd)
 		{
 			bool skippedForward = false;
-			
+
 			if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (TCHAR*)addr, &moduleHandle) == FALSE)
 			{
 				// not a known module
 				if ((region->State & MEM_COMMIT) == MEM_COMMIT &&
 					((region->Protect == PAGE_READONLY) ||
-					(region->Protect == PAGE_READWRITE) || 
-					(region->Protect == PAGE_EXECUTE_READ) || 
-					(region->Protect == PAGE_EXECUTE_READWRITE) || 
-					(region->Protect == PAGE_EXECUTE_WRITECOPY)))
+						(region->Protect == PAGE_READWRITE) ||
+						(region->Protect == PAGE_EXECUTE_READ) ||
+						(region->Protect == PAGE_EXECUTE_READWRITE) ||
+						(region->Protect == PAGE_EXECUTE_WRITECOPY)))
 				{
 					auto moduleData = static_cast<PBYTE>(region->BaseAddress);
 					if (moduleData[0] == 'M' && moduleData[1] == 'Z')
@@ -385,7 +385,7 @@ BOOL ScanForModules_MemoryWalk_Hidden()
 				}
 			}
 
-			SecureZeroMemory(moduleName, sizeof(TCHAR)*MAX_PATH);
+			SecureZeroMemory(moduleName, sizeof(TCHAR) * MAX_PATH);
 			DWORD len;
 			if ((len = GetMappedFileName(GetCurrentProcess(), region->AllocationBase, moduleName, MAX_PATH)) > 0)
 			{
@@ -413,7 +413,6 @@ BOOL ScanForModules_MemoryWalk_Hidden()
 BOOL ScanForModules_DotNetModuleStructures()
 {
 	HMODULE moduleHandle = 0;
-	TCHAR moduleName[MAX_PATH];
 
 	auto memoryRegions = enumerate_memory();
 
@@ -517,8 +516,7 @@ std::vector<LDR_DATA_TABLE_ENTRY*>* WalkLDR(PPEB_LDR_DATA ldrData)
 			printf(" [!] Error reading entry.\n");
 			break;
 		}
-	}
-	while (node != head);
+	} while (node != head);
 
 	entryList->pop_back();
 
@@ -603,7 +601,7 @@ BOOL ScanForModules_LDR_Direct()
 			{
 				PPEB64 peb64 = reinterpret_cast<PPEB64>(GetPeb64());
 				PEB_LDR_DATA64 ldrData = { 0 };
-				
+
 				if (peb64 && attempt_to_read_memory_wow64(&ldrData, sizeof(PEB_LDR_DATA64), peb64->Ldr))
 				{
 					auto ldrEntries = WalkLDR(&ldrData);
@@ -623,7 +621,7 @@ BOOL ScanForModules_LDR_Direct()
 						{
 							printf(" [!] Failed to read module name at %llx.\n", reinterpret_cast<ULONGLONG>(ldrEntry->FullDllName.Buffer));
 						}
-						delete [] dllNameBuffer;
+						delete[] dllNameBuffer;
 						delete ldrEntry;
 					}
 					delete ldrEntries;
@@ -635,7 +633,7 @@ BOOL ScanForModules_LDR_Direct()
 	return anyBadLibs ? TRUE : FALSE;
 }
 
-VOID NTAPI LdrEnumCallback(_In_ PLDR_DATA_TABLE_ENTRY ModuleInformation, _In_ PVOID Parameter, _Out_ BOOLEAN *Stop)
+VOID NTAPI LdrEnumCallback(_In_ PLDR_DATA_TABLE_ENTRY ModuleInformation, _In_ PVOID Parameter, _Out_ BOOLEAN* Stop)
 {
 	// add ldr entry to table from param
 	auto ldtEntries = static_cast<std::vector<LDR_DATA_TABLE_ENTRY>*>(Parameter);

--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -51,11 +51,11 @@ VOID known_file_names() {
 	/* Array of strings of filenames seen in sandboxes */
 	CONST TCHAR* szFilenames[] = {
 		_T("sample.exe"),
-		_T("bot.exe"),		
-		_T("sandbox.exe"),		
-		_T("malware.exe"),	
-		_T("test.exe"),	
-		_T("klavme.exe"),		
+		_T("bot.exe"),
+		_T("sandbox.exe"),
+		_T("malware.exe"),
+		_T("test.exe"),
+		_T("klavme.exe"),
 		_T("myapp.exe"),
 		_T("testapp.exe"),
 
@@ -74,7 +74,7 @@ VOID known_file_names() {
 
 	// Get the file name from path/
 	WCHAR* szFileName = PathFindFileNameW(pPeb->ProcessParameters->ImagePathName.Buffer);
-	
+
 	TCHAR msg[256] = _T("");
 	WORD dwlength = sizeof(szFilenames) / sizeof(szFilenames[0]);
 	for (int i = 0; i < dwlength; i++)
@@ -91,17 +91,17 @@ VOID known_file_names() {
 	// Some malware do check if the file name is a known hash (like md5 or sha1)
 	PathRemoveExtensionW(szFileName);
 	_stprintf_s(msg, sizeof(msg) / sizeof(TCHAR), _T("Checking if process file name looks like a hash: %s "), szFileName);
-	if ( (wcslen(szFileName) == 32 || wcslen(szFileName) == 40 || wcslen(szFileName) == 64) && IsHexString(szFileName))
+	if ((wcslen(szFileName) == 32 || wcslen(szFileName) == 40 || wcslen(szFileName) == 64) && IsHexString(szFileName))
 		print_results(TRUE, msg);
-	else 
+	else
 		print_results(FALSE, msg);
 }
 
-static TCHAR * get_username() {
-	TCHAR *username;
+static TCHAR* get_username() {
+	TCHAR* username;
 	DWORD nSize = (UNLEN + 1);
 
-	username = (TCHAR *) malloc(nSize * sizeof(TCHAR));
+	username = (TCHAR*)malloc(nSize * sizeof(TCHAR));
 	if (!username) {
 		return NULL;
 	}
@@ -152,7 +152,7 @@ VOID known_usernames() {
 		 * https://blog.trendmicro.com/trendlabs-security-intelligence/new-emotet-hijacks-windows-api-evades-sandbox-analysis/ */
 		_T("John Doe"), /* VirusTotal Cuckoofork Sandbox */
 	};
-	TCHAR *username;
+	TCHAR* username;
 
 	if (NULL == (username = get_username())) {
 		return;
@@ -176,11 +176,11 @@ VOID known_usernames() {
 	free(username);
 }
 
-static TCHAR * get_netbios_hostname() {
-	TCHAR *hostname;
+static TCHAR* get_netbios_hostname() {
+	TCHAR* hostname;
 	DWORD nSize = (MAX_COMPUTERNAME_LENGTH + 1);
 
-	hostname = (TCHAR *) malloc(nSize * sizeof(TCHAR));
+	hostname = (TCHAR*)malloc(nSize * sizeof(TCHAR));
 	if (!hostname) {
 		return NULL;
 	}
@@ -191,12 +191,12 @@ static TCHAR * get_netbios_hostname() {
 	return hostname;
 }
 
-static TCHAR * get_dns_hostname() {
-	TCHAR *hostname;
+static TCHAR* get_dns_hostname() {
+	TCHAR* hostname;
 	DWORD nSize = 0;
 
 	GetComputerNameEx(ComputerNameDnsHostname, NULL, &nSize);
-	hostname = (TCHAR *) malloc((nSize + 1) * sizeof(TCHAR));
+	hostname = (TCHAR*)malloc((nSize + 1) * sizeof(TCHAR));
 	if (!hostname) {
 		return NULL;
 	}
@@ -234,8 +234,8 @@ VOID known_hostnames() {
 		 * https://blog.trendmicro.com/trendlabs-security-intelligence/new-emotet-hijacks-windows-api-evades-sandbox-analysis/ */
 		_T("TEQUILABOOMBOOM"), /* VirusTotal Cuckoofork Sandbox */
 	};
-	TCHAR *NetBIOSHostName;
-	TCHAR *DNSHostName;
+	TCHAR* NetBIOSHostName;
+	TCHAR* DNSHostName;
 
 	if (NULL == (NetBIOSHostName = get_netbios_hostname())) {
 		return;
@@ -272,9 +272,9 @@ VOID known_hostnames() {
 Check for a combination of environmental conditions, replicating what malware
 could/has used to detect that it's running in a sandbox. */
 VOID other_known_sandbox_environment_checks() {
-	TCHAR *NetBIOSHostName;
-	TCHAR *DNSHostName;
-	TCHAR *username;
+	TCHAR* NetBIOSHostName;
+	TCHAR* DNSHostName;
+	TCHAR* username;
 	BOOL matched;
 
 	if (NULL == (username = get_username())) {
@@ -296,47 +296,47 @@ VOID other_known_sandbox_environment_checks() {
 	matched = FALSE;
 	if ((0 == StrCmp(username, _T("Wilber"))) &&
 		((0 == StrCmpNI(NetBIOSHostName, _T("SC"), 2)) ||
-	     (0 == StrCmpNI(NetBIOSHostName, _T("SW"), 2)))) {
+			(0 == StrCmpNI(NetBIOSHostName, _T("SW"), 2)))) {
 		matched = TRUE;
 	}
-	print_results(matched, (TCHAR *)_T("Checking whether username is 'Wilber' and NetBIOS name starts with 'SC' or 'SW' "));
+	print_results(matched, (TCHAR*)_T("Checking whether username is 'Wilber' and NetBIOS name starts with 'SC' or 'SW' "));
 
 	matched = FALSE;
 	if ((0 == StrCmp(username, _T("admin"))) && (0 == StrCmp(NetBIOSHostName, _T("SystemIT")))) {
 		matched = TRUE;
 	}
-	print_results(matched, (TCHAR *)_T("Checking whether username is 'admin' and NetBIOS name is 'SystemIT' "));
+	print_results(matched, (TCHAR*)_T("Checking whether username is 'admin' and NetBIOS name is 'SystemIT' "));
 
 	matched = FALSE;
 	if ((0 == StrCmp(username, _T("admin"))) && (0 == StrCmp(DNSHostName, _T("KLONE_X64-PC")))) {
 		matched = TRUE;
 	}
-	print_results(matched, (TCHAR *) _T("Checking whether username is 'admin' and DNS hostname is 'KLONE_X64-PC' "));
+	print_results(matched, (TCHAR*)_T("Checking whether username is 'admin' and DNS hostname is 'KLONE_X64-PC' "));
 
 	matched = FALSE;
 	if ((0 == StrCmp(username, _T("John"))) &&
-		(is_FileExists((TCHAR *)_T("C:\\take_screenshot.ps1"))) &&
-		(is_FileExists((TCHAR *)_T("C:\\loaddll.exe")))) {
+		(is_FileExists((TCHAR*)_T("C:\\take_screenshot.ps1"))) &&
+		(is_FileExists((TCHAR*)_T("C:\\loaddll.exe")))) {
 		matched = TRUE;
 	}
-	print_results(matched, (TCHAR *)_T("Checking whether username is 'John' and two sandbox files exist "));
+	print_results(matched, (TCHAR*)_T("Checking whether username is 'John' and two sandbox files exist "));
 
 	matched = FALSE;
-	if ((is_FileExists((TCHAR *)_T("C:\\email.doc"))) &&
-		(is_FileExists((TCHAR *)_T("C:\\email.htm"))) &&
-		(is_FileExists((TCHAR *)_T("C:\\123\\email.doc"))) &&
-		(is_FileExists((TCHAR *)_T("C:\\123\\email.docx")))) {
+	if ((is_FileExists((TCHAR*)_T("C:\\email.doc"))) &&
+		(is_FileExists((TCHAR*)_T("C:\\email.htm"))) &&
+		(is_FileExists((TCHAR*)_T("C:\\123\\email.doc"))) &&
+		(is_FileExists((TCHAR*)_T("C:\\123\\email.docx")))) {
 		matched = TRUE;
 	}
-	print_results(matched, (TCHAR *)_T("Checking whether four known sandbox 'email' file paths exist "));
+	print_results(matched, (TCHAR*)_T("Checking whether four known sandbox 'email' file paths exist "));
 
 	matched = FALSE;
-	if ((is_FileExists((TCHAR *)_T("C:\\a\\foobar.bmp"))) &&
-		(is_FileExists((TCHAR *)_T("C:\\a\\foobar.doc"))) &&
-		(is_FileExists((TCHAR *)_T("C:\\a\\foobar.gif")))) {
+	if ((is_FileExists((TCHAR*)_T("C:\\a\\foobar.bmp"))) &&
+		(is_FileExists((TCHAR*)_T("C:\\a\\foobar.doc"))) &&
+		(is_FileExists((TCHAR*)_T("C:\\a\\foobar.gif")))) {
 		matched = TRUE;
 	}
-	print_results(matched, (TCHAR *)_T("Checking whether three known sandbox 'foobar' files exist "));
+	print_results(matched, (TCHAR*)_T("Checking whether three known sandbox 'foobar' files exist "));
 
 	free(username);
 	free(NetBIOSHostName);
@@ -451,8 +451,8 @@ Check number of cores using WMI
 */
 BOOL number_cores_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -467,7 +467,7 @@ BOOL number_cores_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -545,8 +545,8 @@ Check hard disk size using WMI
 */
 BOOL disk_size_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -562,7 +562,7 @@ BOOL disk_size_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -572,13 +572,13 @@ BOOL disk_size_wmi()
 				hRes = pEnumerator->Next(WBEM_INFINITE, 1, &pclsObj, &uReturn);
 				if (0 == uReturn)
 					break;
-				
+
 				// Don`t check removable disk, network drive CD-ROM and RAM disk
 				if (checkDriveType(pclsObj)) {
 					pclsObj->Release();
 					continue;
 				}
-				
+
 				// Get the value of the Name property
 				hRes = pclsObj->Get(_T("Size"), 0, &vtProp, NULL, 0);
 				if (SUCCEEDED(hRes)) {
@@ -594,7 +594,7 @@ BOOL disk_size_wmi()
 							if (diskSizeBytes < minHardDiskSize) { // Less than 80GB
 								bFound = TRUE;
 							}
-						}	
+						}
 						// release the current result object
 						VariantClear(&vtProp);
 					}
@@ -1011,7 +1011,7 @@ BOOL cpuid_hypervisor_vendor()
 {
 	INT CPUInfo[4] = { -1 };
 	CHAR szHypervisorVendor[0x40];
-	WCHAR *pwszConverted;
+	WCHAR* pwszConverted;
 
 	BOOL bResult = FALSE;
 
@@ -1057,8 +1057,8 @@ Check SerialNumber devices using WMI
 */
 BOOL serial_number_bios_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1074,7 +1074,7 @@ BOOL serial_number_bios_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -1128,8 +1128,8 @@ Check Model from ComputerSystem using WMI
 */
 BOOL model_computer_system_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1145,7 +1145,7 @@ BOOL model_computer_system_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -1197,8 +1197,8 @@ Check Manufacturer from ComputerSystem using WMI
 */
 BOOL manufacturer_computer_system_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1214,7 +1214,7 @@ BOOL manufacturer_computer_system_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -1267,8 +1267,8 @@ In my tests, it works against vbox, vmware, kvm and xen.
 */
 BOOL current_temperature_acpi_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1288,7 +1288,7 @@ BOOL current_temperature_acpi_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -1330,8 +1330,8 @@ KVM, XEN anv VMWare seems to return something, VBOX return NULL
 */
 BOOL process_id_processor_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1347,7 +1347,7 @@ BOOL process_id_processor_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -1415,8 +1415,8 @@ which would most likely be true in a non-virtual environment.
 */
 BOOL cpu_fan_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1432,7 +1432,7 @@ BOOL cpu_fan_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 
 			while (pEnumerator)
@@ -1466,8 +1466,8 @@ Check Caption from VideoController using WMI
 */
 BOOL caption_video_controller_wmi()
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1483,7 +1483,7 @@ BOOL caption_video_controller_wmi()
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 			VARIANT vtProp;
 
@@ -1556,8 +1556,8 @@ BOOL query_license_value()
 
 int wmi_query_count(const _TCHAR* query)
 {
-	IWbemServices *pSvc = NULL;
-	IWbemLocator *pLoc = NULL;
+	IWbemServices* pSvc = NULL;
+	IWbemLocator* pLoc = NULL;
 	IEnumWbemClassObject* pEnumerator = NULL;
 	BOOL bStatus = FALSE;
 	HRESULT hRes;
@@ -1573,7 +1573,7 @@ int wmi_query_count(const _TCHAR* query)
 		if (bStatus)
 		{
 			// Get the data from the query
-			IWbemClassObject *pclsObj = NULL;
+			IWbemClassObject* pclsObj = NULL;
 			ULONG uReturn = 0;
 
 			// Iterate over our enumator
@@ -1927,7 +1927,7 @@ BOOL registry_disk_enum()
 		}
 
 		DWORD subKeyBufferLen = (cbMaxSubKeyLen + 1) * sizeof(TCHAR);
-		TCHAR* subKeyBuffer = (TCHAR *)malloc(subKeyBufferLen);
+		TCHAR* subKeyBuffer = (TCHAR*)malloc(subKeyBufferLen);
 		if (!subKeyBuffer) {
 			RegCloseKey(hkResult);
 			continue;
@@ -2002,7 +2002,7 @@ BOOL check_tables_number(const PBYTE smbios)
 		BYTE    mnVer;            // Minor part of the SMB version(minor)
 		BYTE    dmiRev;           // DMI version(obsolete)
 		DWORD   length;           // Data table size
-		BYTE    tableData[];      // Table data
+		BYTE    tableData[1];      // Table data
 	};
 
 	RawSMBIOSData* smBiosData = reinterpret_cast<RawSMBIOSData*>(smbios);
@@ -2046,7 +2046,7 @@ BOOL number_SMBIOS_tables()
 }
 
 /*
-Check for generic 
+Check for generic
 */
 BOOL firmware_ACPI()
 {
@@ -2078,7 +2078,7 @@ BOOL firmware_ACPI()
 			size_t batteryDeviceLen = 7;
 			BOOL needsBatteryCheck = false;
 
-			const char *requiredDevices[] = {
+			const char* requiredDevices[] = {
 				"PNP0000",	// 8259-compatible Programmable Interrupt Controller
 				"PNP0C0C",	// Power Button Device
 				"PNP0C0E",	// Sleep Button Device
@@ -2086,7 +2086,7 @@ BOOL firmware_ACPI()
 				"PNP0D80",	// Windows-compatible System Power Management Controller
 			};
 
-restart:
+		restart:
 			for (DWORD i = 0; i < tableCount; i++)
 			{
 				DWORD tableSize = 0;
@@ -2138,7 +2138,7 @@ restart:
 				}
 			}
 		}
-out:
+	out:
 		free(tableNames);
 	}
 	return result || !foundWSMT;
@@ -2237,7 +2237,7 @@ Looking-glass requires at least one of them:
 */
 VOID looking_glass_vdd_processes()
 {
-	const TCHAR *szProcesses[] = {
+	const TCHAR* szProcesses[] = {
 		_T("looking-glass-host.exe"), 	// Looking-Glass.io
 		_T("VDDSysTray.exe"),			// VirtualDisplayDriver, used in conjunction
 	};

--- a/al-khaser/Shared/Utils.cpp
+++ b/al-khaser/Shared/Utils.cpp
@@ -4,7 +4,7 @@
 BOOL IsWoW64()
 {
 	BOOL bIsWow64 = FALSE;
-	
+
 	if (API::IsAvailable(API_IDENTIFIER::API_IsWow64Process))
 	{
 		auto fnIsWow64Process = static_cast<pIsWow64Process>(API::GetAPI(API_IDENTIFIER::API_IsWow64Process));
@@ -27,7 +27,7 @@ PVOID64 GetPeb64()
 
 		auto NtWow64QueryInformationProcess64 = static_cast<pNtWow64QueryInformationProcess64>(API::GetAPI(API_IDENTIFIER::API_NtWow64QueryInformationProcess64));
 		NTSTATUS status = NtWow64QueryInformationProcess64(GetCurrentProcess(), ProcessBasicInformation, &pbi64, sizeof(pbi64), nullptr);
-		if ( NT_SUCCESS ( status ) )
+		if (NT_SUCCESS(status))
 			peb64 = pbi64.PebBaseAddress;
 	}
 
@@ -58,75 +58,75 @@ BOOL Is_RegKeyValueExists(HKEY hKey, const TCHAR* lpSubKey, const TCHAR* lpValue
 
 BOOL Is_RegKeyExists(HKEY hKey, const TCHAR* lpSubKey)
 {
-    if (_tcschr(lpSubKey, _T('*')) == NULL && _tcschr(lpSubKey, _T('?')) == NULL)
-    {
-        HKEY hkResult = NULL;
-        if (RegOpenKeyEx(hKey, lpSubKey, 0, KEY_READ, &hkResult) == ERROR_SUCCESS)
-        {
-            RegCloseKey(hkResult);
-            return TRUE;
-        }
-        return FALSE;
-    }
-    else
-    {
-        const TCHAR* lastBackslash = _tcsrchr(lpSubKey, _T('\\'));
-        TCHAR parentPath[MAX_PATH] = {0};
-        TCHAR childPattern[MAX_PATH] = {0};
+	if (_tcschr(lpSubKey, _T('*')) == NULL && _tcschr(lpSubKey, _T('?')) == NULL)
+	{
+		HKEY hkResult = NULL;
+		if (RegOpenKeyEx(hKey, lpSubKey, 0, KEY_READ, &hkResult) == ERROR_SUCCESS)
+		{
+			RegCloseKey(hkResult);
+			return TRUE;
+		}
+		return FALSE;
+	}
+	else
+	{
+		const TCHAR* lastBackslash = _tcsrchr(lpSubKey, _T('\\'));
+		TCHAR parentPath[MAX_PATH] = { 0 };
+		TCHAR childPattern[MAX_PATH] = { 0 };
 
-        if (lastBackslash != NULL)
-        {
-            size_t parentLen = lastBackslash - lpSubKey;
-            _tcsncpy_s(parentPath, _countof(parentPath), lpSubKey, parentLen);
-            _tcscpy_s(childPattern, _countof(childPattern), lastBackslash + 1);
-        }
-        else
-        {
-            _tcscpy_s(childPattern, _countof(childPattern), lpSubKey);
-        }
+		if (lastBackslash != NULL)
+		{
+			size_t parentLen = lastBackslash - lpSubKey;
+			_tcsncpy_s(parentPath, _countof(parentPath), lpSubKey, parentLen);
+			_tcscpy_s(childPattern, _countof(childPattern), lastBackslash + 1);
+		}
+		else
+		{
+			_tcscpy_s(childPattern, _countof(childPattern), lpSubKey);
+		}
 
-        HKEY hKeyParent = NULL;
-        LONG lResult = RegOpenKeyEx(hKey, parentPath, 0, KEY_READ, &hKeyParent);
-        if (lResult != ERROR_SUCCESS)
-        {
-            return FALSE;
-        }
+		HKEY hKeyParent = NULL;
+		LONG lResult = RegOpenKeyEx(hKey, parentPath, 0, KEY_READ, &hKeyParent);
+		if (lResult != ERROR_SUCCESS)
+		{
+			return FALSE;
+		}
 
-        TCHAR childPatternUpper[MAX_PATH];
-        _tcscpy_s(childPatternUpper, _countof(childPatternUpper), childPattern);
-        _tcsupr_s(childPatternUpper, _countof(childPatternUpper));
+		TCHAR childPatternUpper[MAX_PATH];
+		_tcscpy_s(childPatternUpper, _countof(childPatternUpper), childPattern);
+		_tcsupr_s(childPatternUpper, _countof(childPatternUpper));
 
-        DWORD dwIndex = 0;
-        TCHAR subkeyName[MAX_PATH];
-        DWORD cchName = MAX_PATH;
-        BOOL bFound = FALSE;
+		DWORD dwIndex = 0;
+		TCHAR subkeyName[MAX_PATH];
+		DWORD cchName = MAX_PATH;
+		BOOL bFound = FALSE;
 
-        while (1)
-        {
-            cchName = MAX_PATH;
-            lResult = RegEnumKeyEx(hKeyParent, dwIndex, subkeyName, &cchName, NULL, NULL, NULL, NULL);
-            if (lResult == ERROR_NO_MORE_ITEMS)
-                break;
-            if (lResult != ERROR_SUCCESS)
-                break;
+		while (1)
+		{
+			cchName = MAX_PATH;
+			lResult = RegEnumKeyEx(hKeyParent, dwIndex, subkeyName, &cchName, NULL, NULL, NULL, NULL);
+			if (lResult == ERROR_NO_MORE_ITEMS)
+				break;
+			if (lResult != ERROR_SUCCESS)
+				break;
 
-            TCHAR subkeyUpper[MAX_PATH];
-            _tcscpy_s(subkeyUpper, _countof(subkeyUpper), subkeyName);
-            _tcsupr_s(subkeyUpper, _countof(subkeyUpper));
+			TCHAR subkeyUpper[MAX_PATH];
+			_tcscpy_s(subkeyUpper, _countof(subkeyUpper), subkeyName);
+			_tcsupr_s(subkeyUpper, _countof(subkeyUpper));
 
-            // Check if the subkey matches the pattern
-            if (PathMatchSpec(subkeyUpper, childPatternUpper))
-            {
-                bFound = TRUE;
-                break;
-            }
+			// Check if the subkey matches the pattern
+			if (PathMatchSpec(subkeyUpper, childPatternUpper))
+			{
+				bFound = TRUE;
+				break;
+			}
 
-            dwIndex++;
-        }
+			dwIndex++;
+		}
 
-        RegCloseKey(hKeyParent);
-        return bFound;
-    }
+		RegCloseKey(hKeyParent);
+		return bFound;
+	}
 }
 
 BOOL is_FileExists(TCHAR* szPath)
@@ -203,7 +203,7 @@ BOOL check_adapter_name(const TCHAR* szName)
 	PIP_ADAPTER_INFO pAdapterInfo, pAdapterInfoPtr;
 	ULONG ulOutBufLen = sizeof(IP_ADAPTER_INFO);
 
-	WCHAR *pwszConverted;
+	WCHAR* pwszConverted;
 
 	pAdapterInfo = (PIP_ADAPTER_INFO)MALLOC(sizeof(IP_ADAPTER_INFO));
 	if (pAdapterInfo == NULL)
@@ -691,7 +691,7 @@ BOOL SetDebugPrivileges(VOID) {
 	priv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
 	if (LookupPrivilegeValue(NULL, SE_DEBUG_NAME, &priv.Privileges[0].Luid)) {
-		
+
 		bResult = AdjustTokenPrivileges(hToken, FALSE, &priv, 0, NULL, NULL);
 		if (!bResult) {
 			print_last_error(_T("AdjustTokenPrivileges"));
@@ -795,7 +795,7 @@ DWORD GetMainThreadId(DWORD pid)
 	return (DWORD)0;
 }
 
-BOOL InitWMI(IWbemServices **pSvc, IWbemLocator **pLoc, const TCHAR* szNetworkResource)
+BOOL InitWMI(IWbemServices** pSvc, IWbemLocator** pLoc, const TCHAR* szNetworkResource)
 {
 	// Initialize COM.
 	HRESULT hres;
@@ -850,7 +850,7 @@ BOOL InitWMI(IWbemServices **pSvc, IWbemLocator **pLoc, const TCHAR* szNetworkRe
 	return 1;
 }
 
-BOOL ExecWMIQuery(IWbemServices **pSvc, IWbemLocator **pLoc, IEnumWbemClassObject **pEnumerator, const TCHAR* szQuery)
+BOOL ExecWMIQuery(IWbemServices** pSvc, IWbemLocator** pLoc, IEnumWbemClassObject** pEnumerator, const TCHAR* szQuery)
 {
 	// Execute WMI query
 	BSTR strQueryLanguage = SysAllocString(OLESTR("WQL"));
@@ -894,7 +894,7 @@ ULONG get_idt_base()
 #if defined (ENV32BIT)
 	_asm sidt idtr
 #endif
-	idt = *((unsigned long *)&idtr[2]);
+	idt = *((unsigned long*)&idtr[2]);
 	// printf("IDT base: 0x%x\n", idt);
 
 	return idt;
@@ -913,7 +913,7 @@ ULONG get_ldt_base()
 #if defined (ENV32BIT)
 	_asm sldt ldtr
 #endif
-	ldt = *((unsigned long *)&ldtr[0]);
+	ldt = *((unsigned long*)&ldtr[0]);
 	// printf("LDT base: 0x%x\n", ldt);
 
 	return ldt;
@@ -932,7 +932,7 @@ ULONG get_gdt_base()
 #if defined (ENV32BIT)
 	_asm sgdt gdtr
 #endif
-	gdt = *((unsigned long *)&gdtr[2]);
+	gdt = *((unsigned long*)&gdtr[2]);
 	// printf("GDT base: 0x%x\n", gdt);
 
 	return gdt;
@@ -999,7 +999,7 @@ PBYTE get_system_firmware(_In_ DWORD signature, _In_ DWORD table, _Out_ PDWORD p
 		return NULL;
 
 	SecureZeroMemory(firmwareTable, bufferSize);
-	
+
 	auto GetSystemFirmwareTable = static_cast<pGetSystemFirmwareTable>(API::GetAPI(API_IDENTIFIER::API_GetSystemFirmwareTable));
 
 	DWORD resultBufferSize = GetSystemFirmwareTable(signature, table, firmwareTable, bufferSize);
@@ -1084,7 +1084,7 @@ std::vector<PMEMORY_BASIC_INFORMATION>* enumerate_memory()
 		auto mbi = new MEMORY_BASIC_INFORMATION();
 		if (VirtualQuery(addr, mbi, sizeof(MEMORY_BASIC_INFORMATION)) <= 0)
 			break;
-		
+
 		regions->push_back(mbi);
 
 		addr += mbi->RegionSize;
@@ -1143,9 +1143,9 @@ std::vector<wchar_t*>* enumerate_object_directory(const wchar_t* path)
 
 	UNICODE_STRING usPath = { 0 };
 	usPath.Buffer = const_cast<wchar_t*>(path);
-	usPath.Length = lstrlenW(path) * sizeof(wchar_t);
+	usPath.Length = static_cast<USHORT>(lstrlenW(path) * sizeof(wchar_t));
 	usPath.MaximumLength = usPath.Length;
-	
+
 	OBJECT_ATTRIBUTES objAttr = { 0 };
 	InitializeObjectAttributes(&objAttr, &usPath, OBJ_CASE_INSENSITIVE, NULL, NULL);
 

--- a/al-khaser/TimingAttacks/timing.cpp
+++ b/al-khaser/TimingAttacks/timing.cpp
@@ -34,18 +34,18 @@ BOOL timing_SetTimer(UINT delayInMillis)
 {
 	MSG Msg;
 	UINT_PTR iTimerID;
-	
+
 	// Set our timer without window handle
 	iTimerID = SetTimer(NULL, 0, delayInMillis, TimerProc);
 
 	if (iTimerID == NULL)
 		return TRUE;
-	
+
 	// Because we are running in a console app, we should get the messages from
 	// the queue and check if msg is WM_TIMER
-	while (GetMessage(&Msg, NULL, 0, 0) & !bProcessed) 
+	while (GetMessage(&Msg, NULL, 0, 0) & !bProcessed)
 	{
-		TranslateMessage(&Msg); 
+		TranslateMessage(&Msg);
 		DispatchMessage(&Msg);
 	}
 
@@ -83,7 +83,7 @@ BOOL timing_timeSetEvent(UINT delayInMillis)
 	if (idEvent == NULL)
 		return TRUE;
 
-	while (!bProcessed){
+	while (!bProcessed) {
 		// wait until uor function finish
 	}
 
@@ -118,9 +118,8 @@ BOOL timing_WaitForSingleObject(UINT delayInMillis)
 }
 
 BOOL timing_WaitForMultipleObjects(UINT delayInMillis) {
-	HANDLE hThread;
 	HANDLE ghEvents[2];
-	DWORD i, dwEvent, dwThreadID;
+	DWORD i, dwEvent;
 
 	// Create two event objects
 
@@ -148,9 +147,9 @@ BOOL timing_WaitForMultipleObjects(UINT delayInMillis) {
 	return FALSE;
 }
 
-BOOL timing_sleep_loop (UINT delayInMillis)
+BOOL timing_sleep_loop(UINT delayInMillis)
 {
-	/* 
+	/*
 	This trick is about performing a low number of seconds to sleep but in a loop,
 	the reason behind that sandboxes tries to avoid patching such sleeps because it
 	could lead to race conditions and also because it is just negliable. However,
@@ -158,7 +157,7 @@ BOOL timing_sleep_loop (UINT delayInMillis)
 	its timeout.
 	*/
 
-	int delayInMillis_divided  = delayInMillis / 1000;
+	int delayInMillis_divided = delayInMillis / 1000;
 
 	/* Example: we want to sleep 300 seeconds, then we can sleep
 	0.3s for 1000 times which is like: 300 seconds = 5 minues */
@@ -212,7 +211,7 @@ BOOL rdtsc_diff_locky()
 
 
 /*
-CPUID is an instruction which cauz a VM Exit to the VMM, 
+CPUID is an instruction which cauz a VM Exit to the VMM,
 this little overhead can show the presence of a hypervisor
 */
 
@@ -241,7 +240,7 @@ BOOL rdtsc_diff_vmexit()
 
 
 /*
-Another timinig attack using the API IcmpSendEcho which takes a TimeOut 
+Another timinig attack using the API IcmpSendEcho which takes a TimeOut
 in milliseconds as a parameter, to wait for IPv4 ICMP packets replies.
 First time observed: http://blog.talosintelligence.com/2017/09/avast-distributes-malware.html
 */
@@ -291,9 +290,9 @@ BOOL timing_CreateWaitableTimer(UINT delayInMillis)
 	BOOL bResult = FALSE;
 
 	dueTime.QuadPart = delayInMillis * -10000LL;
-	
+
 	hTimer = CreateWaitableTimer(NULL, TRUE, NULL);
-	
+
 	if (hTimer == NULL)
 	{
 		return TRUE;


### PR DESCRIPTION
DONE: 
- fix build warning 
- apply code style for modified src-files

This MR fixes the following noisy warnings:
```
AntiDebug\ScanForModules.cpp(416,8): warning C4101: 'moduleName': unreferenced local variable
AntiVM\Generic.cpp(2005,11): warning C4200: nonstandard extension used: zero-sized array in struct/union
Shared\Utils.cpp(1146,33): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
TimingAttacks\timing.cpp(121,9): warning C4101: 'hThread': unreferenced local variable
TimingAttacks\timing.cpp(123,20): warning C4101: 'dwThreadID': unreferenced local variable
```