### PR TITLE
Parametrized --sleep/--delay seconds. Added -h/--help.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,39 @@ It performs a bunch of common malware tricks with the goal of seeing if you stay
 
 ![Logo](https://i.imgur.com/jEFhsJT.png)
 
+### Usage
+```
+$ ./al-khaser.exe -h
+Usage: al-khaser.exe [OPTIONS]
+Options:
+  --check <type>      Enable specific check(s). Can be used multiple times. Valid types are:
+                        TLS              (Thread Local Storage callback checks)
+                        DEBUG            (Anti-debugging checks)
+                        INJECTION        (Code injection checks)
+                        GEN_SANDBOX      (Generic sandbox checks)
+                        VBOX             (VirtualBox detection)
+                        VMWARE           (VMware detection)
+                        VPC              (Virtual PC detection)
+                        QEMU             (QEMU detection)
+                        KVM              (KVM detection)
+                        XEN              (Xen detection)
+                        WINE             (Wine detection)
+                        PARALLELS        (Parallels detection)
+                        HYPERV           (Hyper-V detection)
+                        CODE_INJECTIONS  (Additional code injection techniques)
+                        TIMING_ATTACKS   (Timing/sleep-based sandbox evasion)
+                        DUMPING_CHECK    (Dumping memory/process checks)
+                        ANALYSIS_TOOLS   (Analysis tools detection)
+                        ANTI_DISASSM     (Anti-disassembly checks)
+  --sleep <seconds>   Set sleep/delay duration in seconds (default: 600).
+  --delay <seconds>   Alias for --sleep.
+  -h, --help          Show this help message and exit.
+
+Examples:
+  al-khaser.exe --check DEBUG --check TIMING_ATTACKS --sleep 30
+  al-khaser.exe --check VMWARE --check QEMU
+  al-khaser.exe --sleep 30
+```
 
 ## Download
 

--- a/al-khaser/Al-khaser.cpp
+++ b/al-khaser/Al-khaser.cpp
@@ -22,6 +22,7 @@ BOOL ENABLE_TIMING_ATTACKS = FALSE;
 BOOL ENABLE_DUMPING_CHECK = FALSE;
 BOOL ENABLE_ANALYSIS_TOOLS_CHECK = FALSE;
 BOOL ENABLE_ANTI_DISASSM_CHECKS = FALSE;
+const char* PROGRAM_NAME = "al-khaser.exe";
 
 
 void EnableDefaultChecks() {
@@ -66,16 +67,56 @@ void EnableChecks(std::string checkType) {
 	else if (checkType == "ANTI_DISASSM")		ENABLE_ANTI_DISASSM_CHECKS = TRUE;
 }
 
+void print_help(const char* prog_name){
+	printf(
+		"Usage: %s [OPTIONS]\n"
+		"Options:\n"
+		"  --check <type>      Enable specific check(s). Can be used multiple times. Valid types are:\n"
+		"                        TLS              (Thread Local Storage callback checks)\n"
+		"                        DEBUG            (Anti-debugging checks)\n"
+		"                        INJECTION        (Code injection checks)\n"
+		"                        GEN_SANDBOX      (Generic sandbox checks)\n"
+		"                        VBOX             (VirtualBox detection)\n"
+		"                        VMWARE           (VMware detection)\n"
+		"                        VPC              (Virtual PC detection)\n"
+		"                        QEMU             (QEMU detection)\n"
+		"                        KVM              (KVM detection)\n"
+		"                        XEN              (Xen detection)\n"
+		"                        WINE             (Wine detection)\n"
+		"                        PARALLELS        (Parallels detection)\n"
+		"                        HYPERV           (Hyper-V detection)\n"
+		"                        CODE_INJECTIONS  (Additional code injection techniques)\n"
+		"                        TIMING_ATTACKS   (Timing/sleep-based sandbox evasion)\n"
+		"                        DUMPING_CHECK    (Dumping memory/process checks)\n"
+		"                        ANALYSIS_TOOLS   (Analysis tools detection)\n"
+		"                        ANTI_DISASSM     (Anti-disassembly checks)\n"
+		"  --sleep <seconds>   Set sleep/delay duration in seconds (default: 600).\n"
+		"  --delay <seconds>   Alias for --sleep.\n"
+		"  -h, --help          Show this help message and exit.\n"
+		"\n"
+		"Examples:\n"
+		"  %s --check DEBUG --check TIMING_ATTACKS --sleep 30\n"
+		"  %s --check VMWARE --check QEMU\n"
+		"  %s --sleep 30\n"
+		"\n"
+		"If no --check options are given, all checks are executed by default.\n"
+		"If no other options are given, the default delay is 600 seconds.\n",
+		prog_name, prog_name, prog_name, prog_name
+	);
+}
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]){
 	/* enable functions */
 	UINT delayInSeconds = 600U; // default value
 	int enabled_checks = 0;
 
 	if (argc > 1) {
 		for (int i = 1; i < argc; ++i) {
-			if ((strcmp(argv[i], "--sleep") == 0 || strcmp(argv[i], "--delay") == 0) && i + 1 < argc) {
+			if (strcmp(argv[i], "-h") == 0 || strcmp(argv[i], "--help") == 0) {
+				//print_help(argv[0]);
+				print_help(PROGRAM_NAME);
+				return 0;
+			} else if ((strcmp(argv[i], "--sleep") == 0 || strcmp(argv[i], "--delay") == 0) && i + 1 < argc) {
 				char* endptr;
 				errno = 0;
 				long val = strtol(argv[i + 1], &endptr, 10);
@@ -90,8 +131,7 @@ int main(int argc, char* argv[])
 					delayInSeconds = (UINT)val;
 				}
 				i++; // skip the value
-			}
-			else if ((strcmp(argv[i], "--check") == 0) && i + 1 < argc) {
+			} else if ((strcmp(argv[i], "--check") == 0) && i + 1 < argc) {
 				EnableChecks(argv[i + 1]);
 				enabled_checks++;
 				i++; // skip the value


### PR DESCRIPTION
- Now the amount of seconds (delay) to be used when checking timing attacks can be specified via `--sleep` or `--delay`.
- Now there is a `-h/--help` flag that prints all the available options and provides come usage examples.
- Updated README.

Tested with VS 2022 both for x64 and x86. Building without errors.