### PR TITLE
Fix Windows license check: use WMI to get the detailed status

### DIFF
--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -1803,7 +1803,6 @@ BOOL pirated_windows()
 				if (SUCCEEDED(pclsObj->Get(L"LicenseStatus", 0, &vtProp,
 										   nullptr, nullptr)) &&
 					vtProp.vt == VT_I4) {
-
 					// Do our comparison
 					if (vtProp.lVal == LicenseStatus::UNLICENSED) {
 						bFound = TRUE;


### PR DESCRIPTION
- Replace the legacy SLIsGenuine-based check, which causes false positives in many real-world machines, with a WMI-based SoftwareLicensingProduct query that reads the official LicenseStatus field. 
- Internally previous and newly added approaches query the same ID: `55c92734-d682-4d71-983e-d6ec3f16059f`.
- The new implementation exposes _extended licensing states_ (0–6) defined by Windows, such as grace, allowing us to treat only status **0 (Unlicensed)** as definitively pirated and avoid misclassifying valid configurations.
- see https://learn.microsoft.com/en-us/previous-versions/windows/desktop/sppwmi/softwarelicensingproduct#LicenseStatus

| status| details|
| --- | --- |
| 0 |  Unlicensed |
| 1 |  Licensed |
| 2 |  OOBGrace (Out-of-Box Grace) |
|  3| OOTGrace (Out-of-Tolerance Grace)  |
|  4|  NonGenuineGrace |
|  5|  Notification |
|  6|  ExtendedGrace|
