### PR TITLE
fix: ACPI firmware string check logic is backwards

### DIFF
--- a/al-khaser/AntiVM/Generic.cpp
+++ b/al-khaser/AntiVM/Generic.cpp
@@ -2129,7 +2129,7 @@ BOOL firmware_ACPI()
 
 					for (DWORD j = 0;
 						 j < sizeof(requiredDevices) / sizeof(char *); j++) {
-						if (!find_str_in_data((PBYTE)requiredDevices[j],
+						if (find_str_in_data((PBYTE)requiredDevices[j],
 											  strlen(requiredDevices[j]), table,
 											  tableSize)) {
 							free(table);


### PR DESCRIPTION
- fix: ACPI firmware string check logic is backwards
- a similar issue has been recently fixed - https://github.com/ayoubfaouzi/al-khaser/pull/300
- the original function misclassifies firmware strings for non-sandbox env:

<img width="959" height="408" alt="{B69B4582-98D9-4239-A9AA-3760D9EB08BD}" src="https://github.com/user-attachments/assets/9ca65d3c-7562-402b-89a2-93c299f0eb9d" />

